### PR TITLE
add key update json_string packer

### DIFF
--- a/ubirch/ubirch_protocol_kex.c
+++ b/ubirch/ubirch_protocol_kex.c
@@ -23,6 +23,8 @@
  */
 #include "ubirch_protocol_kex.h"
 
+#define BYTES_LENGTH_TO_BASE64_STRING_LENGTH(__len) (((__len + 2) / 3) * 4)
+
 static const char *proto_reg_key_algorithm = UBIRCH_KEX_ALGORITHM;
 static const char *proto_reg_key_created = UBIRCH_KEX_CREATED;
 static const char *proto_reg_key_uuid = UBIRCH_KEX_UUID;
@@ -36,7 +38,7 @@ static const char *proto_reg_key_valid_not_before = UBIRCH_KEX_VALID_NOT_BEFORE;
  *   1   "algorithm": "ECC_ED25519",
  *   2   "created": 1234567890,
  *   3   "hwDeviceID": "... (convert to UUID style)",
- *   4   "previousPubKeyId": "(convert to base64, optional)"
+ *   4   "prevPubKeyId": "(convert to base64, optional)"
  *   5   "pubKey": "... (convert to base64)",
  *   6   "pubKeyId": "(convert to base64, optional)",
  *   7   "validNotAfter": 1234567899,
@@ -46,7 +48,7 @@ inline int msgpack_pack_key_register(msgpack_packer *pk, ubirch_key_info *info) 
     size_t packetSize = 8;
 
     // reduce size of this packet by checking validity of info
-    if(info->previousPubKeyId == NULL) packetSize -= 1;
+    if(info->prevPubKeyId == NULL) packetSize -= 1;
     if(info->pubKeyId == NULL) packetSize -= 1;
     if(info->validNotAfter == 0) packetSize -= 1;
     if(info->validNotBefore == 0) packetSize -= 1;
@@ -71,11 +73,11 @@ inline int msgpack_pack_key_register(msgpack_packer *pk, ubirch_key_info *info) 
     msgpack_pack_bin_body(pk, info->hwDeviceId, sizeof(info->hwDeviceId));
 
     // 4 - pack the previous pub key id
-    if(info->previousPubKeyId != NULL) {
+    if(info->prevPubKeyId != NULL) {
         msgpack_pack_str(pk, strlen(proto_reg_key_prev_pub_key_id));
         msgpack_pack_str_body(pk, proto_reg_key_prev_pub_key_id, strlen(proto_reg_key_prev_pub_key_id));
-        msgpack_pack_bin(pk, strlen(info->previousPubKeyId));
-        msgpack_pack_bin_body(pk, info->previousPubKeyId, strlen(info->previousPubKeyId));
+        msgpack_pack_bin(pk, strlen(info->prevPubKeyId));
+        msgpack_pack_bin_body(pk, info->prevPubKeyId, strlen(info->prevPubKeyId));
     }
 
     // 5 - pack the public key
@@ -103,4 +105,81 @@ inline int msgpack_pack_key_register(msgpack_packer *pk, ubirch_key_info *info) 
     msgpack_pack_unsigned_int(pk, info->validNotBefore);
 
     return 0;
+}
+
+int json_pack_key_update(ubirch_update_key_info *update, char *json_string_buffer, size_t json_string_buffer_size) {
+    const char *timestring_format = "%Y-%m-%dT%H:%M:%S.000Z";
+    const size_t timestring_size = 25;
+
+    const char *inner_json_format_string =
+        "{"
+            "\"%s\":\"%s\"," /* algorithm */
+            "\"%s\":\"%s\"," /* created */
+            "\"%s\":\"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x\"," /* uuid */
+            "\"%s\":\"%s\"," /* pubKey */
+            "\"%s\":\"%s\"," /* pubKeyId */
+            "\"%s\":\"%s\"," /* prevPubKeyId */
+            "\"%s\":\"%s\"," /* validNotAfter */
+            "\"%s\":\"%s\""  /* validNotBefore */
+        "}";
+
+    // expected size (380)
+    // 6 = number of quotation marks + colon + comma
+    const size_t json_string_size = 2 // {}
+        + 6 + strlen(proto_reg_key_algorithm) + strlen(UBIRCH_KEX_ALG_ECC_ED25519)
+        + 6 + strlen(proto_reg_key_created) + timestring_size
+        + 6 + strlen(proto_reg_key_uuid) + 36
+        + 6 + strlen(proto_reg_key_pub_key) + BYTES_LENGTH_TO_BASE64_STRING_LENGTH(UBIRCH_PROTOCOL_PUBKEY_SIZE)
+        + 6 + strlen(proto_reg_key_pub_key_id) + BYTES_LENGTH_TO_BASE64_STRING_LENGTH(UBIRCH_PROTOCOL_PUBKEY_SIZE)
+        + 6 + strlen(proto_reg_key_prev_pub_key_id) + BYTES_LENGTH_TO_BASE64_STRING_LENGTH(UBIRCH_PROTOCOL_PUBKEY_SIZE)
+        + 6 + strlen(proto_reg_key_valid_not_after) + timestring_size
+        + 5 + strlen(proto_reg_key_valid_not_before) + timestring_size;
+
+    if (json_string_buffer_size < json_string_size) {
+        return -1;
+    }
+
+    // convert unix time to timestring
+    struct tm* timeinfo;
+
+    char timestring_created[timestring_size];
+    timeinfo = localtime(&update->created);
+    strftime(timestring_created, timestring_size, timestring_format, timeinfo);
+
+    char timestring_validNotAfter[timestring_size];
+    timeinfo = localtime(&update->validNotAfter);
+    strftime(timestring_validNotAfter, timestring_size, timestring_format, timeinfo);
+
+    char timestring_validNotBefore[timestring_size];
+    timeinfo = localtime(&update->validNotBefore);
+    strftime(timestring_validNotBefore, timestring_size, timestring_format, timeinfo);
+
+    return sprintf(json_string_buffer, inner_json_format_string,
+        UBIRCH_KEX_ALGORITHM, update->algorithm,
+        UBIRCH_KEX_CREATED, timestring_created,
+        //
+        UBIRCH_KEX_UUID,
+        update->hwDeviceId[0],
+        update->hwDeviceId[1],
+        update->hwDeviceId[2],
+        update->hwDeviceId[3],
+        update->hwDeviceId[4],
+        update->hwDeviceId[5],
+        update->hwDeviceId[6],
+        update->hwDeviceId[7],
+        update->hwDeviceId[8],
+        update->hwDeviceId[9],
+        update->hwDeviceId[10],
+        update->hwDeviceId[11],
+        update->hwDeviceId[12],
+        update->hwDeviceId[13],
+        update->hwDeviceId[14],
+        update->hwDeviceId[15],
+        //
+        UBIRCH_KEX_PUBKEY, update->pubKey,
+        UBIRCH_KEX_PUBKEY_ID, update->pubKey,
+        UBIRCH_KEX_PREV_PUBKEY_ID, update->prevPubKeyId,
+        //
+        UBIRCH_KEX_VALID_NOT_AFTER, timestring_validNotAfter,
+        UBIRCH_KEX_VALID_NOT_BEFORE, timestring_validNotBefore);
 }

--- a/ubirch/ubirch_protocol_kex.h
+++ b/ubirch/ubirch_protocol_kex.h
@@ -32,6 +32,7 @@
 
 #include "ubirch_protocol.h"
 #include <msgpack.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,7 +43,7 @@ extern "C" {
 #define UBIRCH_KEX_ALGORITHM        "algorithm"
 #define UBIRCH_KEX_CREATED          "created"
 #define UBIRCH_KEX_UUID             "hwDeviceId"
-#define UBIRCH_KEX_PREV_PUBKEY_ID   "previousPubKeyId"
+#define UBIRCH_KEX_PREV_PUBKEY_ID   "prevPubKeyId"
 #define UBIRCH_KEX_PUBKEY           "pubKey"
 #define UBIRCH_KEX_PUBKEY_ID        "pubKeyId"
 #define UBIRCH_KEX_VALID_NOT_AFTER  "validNotAfter"
@@ -52,7 +53,7 @@ typedef struct ubirch_key_info {
     char *algorithm;
     unsigned int created;
     unsigned char hwDeviceId[UBIRCH_PROTOCOL_UUID_SIZE];
-    char *previousPubKeyId;
+    char *prevPubKeyId;
     unsigned char pubKey[UBIRCH_PROTOCOL_PUBKEY_SIZE];
     char *pubKeyId;
     unsigned int validNotAfter;
@@ -74,7 +75,7 @@ typedef struct ubirch_key_info {
  *      "algorithm": "ECC_ED25519",
  *      "created": 1234567890,
  *      "hwDeviceID": "... (convert to UUID style)",
- *      "previousPubKeyId": "(convert to base64, optional)",
+ *      "prevPubKeyId": "(convert to base64, optional)",
  *      "pubKey": "... (convert to base64)",
  *      "pubKeyId": "(convert to base64, optional)",
  *      "validNotAfter": 1234567899,
@@ -110,6 +111,21 @@ typedef struct ubirch_key_info {
 int msgpack_pack_key_register(msgpack_packer *pk, ubirch_key_info *info);
 
 
+typedef struct ubirch_update_key_info {
+    char *algorithm;
+    time_t created;
+    unsigned char *hwDeviceId;
+    char *prevPubKeyId;
+    char *pubKey;
+    time_t validNotAfter;
+    time_t validNotBefore;
+} ubirch_update_key_info;
+
+/*
+ *
+ * returns len of string
+ */
+int json_pack_key_update(ubirch_update_key_info *update, char *json_string_buffer, size_t json_string_buffer_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds a function that packs a json-string as expected for a key update. For a complete key update this json-string has to be signed additionally by the old and the new key.